### PR TITLE
[bugfix] 응답 시 UI가 버벅거리는 버그 수정

### DIFF
--- a/LuckyVicky-iOS/View/Content/ContentViewModel.swift
+++ b/LuckyVicky-iOS/View/Content/ContentViewModel.swift
@@ -273,10 +273,8 @@ final class ContentViewModel: ObservableObject {
 // MARK: - AIServiceDelegate
 extension ContentViewModel: @preconcurrency AIServiceDelegate {
   func aiService(_ service: AIServiceProtocol, didGenerateText text: String) {
-    withAnimation(.smooth(duration: 0.5)) {
-      UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
-      state.responseText += text
-    }
+    UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+    state.responseText += text
   }
   
   func aiService(_ service: AIServiceProtocol, didCompleteWithResult result: Result<Void, Error>) {


### PR DESCRIPTION
## 🍀 변경 사항
ContentViewModel 내부에 AI Service로부터 응답을 받아 state.responseText에 추가하는 과정에서 문제가 발생했습니다.
추가하는 과정에서 애니메이션이 동작하는데 내용이 길어지거나, 많아질 경우 메인 스레드의 부담이 커지고 이로 인해 UI가 버벅거렸습니다.

debounce 처리를 하거나 토큰 단위의 응답을 청킹해 애니메이션과 햅틱 주기를 청킹 단위로 주는 방법이 있었지만,
단순히 애니메이션을 제거한다고 해도 크게 어색한 부분이 없고 UX 부분도 오히려 개선되었다고 느껴 제거했습니다.
다만, Delegate 방식으로 접근하는 과정에서 확장성이 떨어지는 부분이 있어(debounce 등) Combine 도입을 고려 중입니다.

## 🚨 관련 이슈

- 관련 이슈: #5 

## ✅ 체크리스트

- [x] 정상 동작 확인